### PR TITLE
use gock for HTTP mocking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.15
 require (
 	github.com/google/go-jsonnet v0.17.0
 	github.com/prometheus/client_golang v1.9.0
+	gopkg.in/h2non/gock.v1 v1.0.16
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
Replace the fakeClient impl with gock. This should open up an easier way to introduce pagination to certain FortiAPI calls, as only one client impl has to be changed/extended to support pagination.

Related to #52 , as the api call used to get load balance servers has a mandatory count param for pagination