### PR TITLE
feat: add max connections metric for each lb real server

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ To improve security, limit permissions to required ones only (least privilege pr
 |BGP/Neighbors/IPv4           | netgrp.route-cfg   |api/v2/monitor/router/bgp/neighbors |
 |BGP/Neighbors/IPv6           | netgrp.route-cfg   |api/v2/monitor/router/bgp/neighbors6 |
 |Firewall/IpPool              | fwgrp.policy       |api/v2/monitor/firewall/ippool |
-|Firewall/LoadBalance         | fwgrp.others       |api/v2/monitor/firewall/load-balance |
+|Firewall/LoadBalance         | fwgrp.others       |api/v2/monitor/firewall/load-balance<br>api/v2/cmdb/firewall/vip |
 |Firewall/Policies            | fwgrp.policy       |api/v2/monitor/firewall/policy/select<br>api/v2/monitor/firewall/policy6/select<br>api/v2/cmdb/firewall/policy<br>api/v2/cmdb/firewall/policy6 |
 |License/Status               | *any*              |api/v2/monitor/license/status/select |
 |Log/Fortianalyzer/Status     | loggrp.config      |api/v2/monitor/log/fortianalyzer |

--- a/metrics.md
+++ b/metrics.md
@@ -209,6 +209,7 @@ Per-VDOM:
    * `fortigate_lb_real_server_active_sessions`
    * `fortigate_lb_real_server_rtt_seconds`
    * `fortigate_lb_real_server_processed_bytes_total`
+   * `fortigate_lb_real_server_max_connections`
 
  Per-Certificate:
  * _System/AvailableCertificates_

--- a/pkg/probe/firewall_load_balance.go
+++ b/pkg/probe/firewall_load_balance.go
@@ -65,6 +65,11 @@ func probeFirewallLoadBalance(c fortigatehttpclient.FortiHTTP, meta *TargetMetad
 			"Number of bytes processed by this real server",
 			[]string{"vdom", "virtual_server", "id"}, nil,
 		)
+		realServerMaxConnections = prometheus.NewDesc(
+			"fortigate_lb_real_server_max_connections",
+			"Configured maximum concurrent connections for this real server (0 = unlimited)",
+			[]string{"vdom", "virtual_server", "id"}, nil,
+		)
 	)
 
 	type RealServer struct {
@@ -104,6 +109,40 @@ func probeFirewallLoadBalance(c fortigatehttpclient.FortiHTTP, meta *TargetMetad
 	if err := c.Get("api/v2/monitor/firewall/load-balance", "vdom=*&start=0&count=1000", &rs); err != nil {
 		log.Printf("Error: %v", err)
 		return nil, false
+	}
+
+	type vipRealServer struct {
+		ID             int `json:"id"`
+		MaxConnections int `json:"max-connections"`
+	}
+	type vipConfig struct {
+		Name        string          `json:"name"`
+		RealServers []vipRealServer `json:"realservers"`
+	}
+	type vipResponse struct {
+		Results []vipConfig
+		VDOM    string
+	}
+
+	var vips []vipResponse
+	if err := c.Get("api/v2/cmdb/firewall/vip", "vdom=*", &vips); err != nil {
+		log.Printf("Error: %v", err)
+		return nil, false
+	}
+
+	maxConnections := map[string]map[int]int{}
+	for _, v := range vips {
+		for _, vc := range v.Results {
+			key := v.VDOM + "\x00" + vc.Name
+			rsMap, ok := maxConnections[key]
+			if !ok {
+				rsMap = map[int]int{}
+				maxConnections[key] = rsMap
+			}
+			for _, rs := range vc.RealServers {
+				rsMap[rs.ID] = rs.MaxConnections
+			}
+		}
 	}
 
 	m := []prometheus.Metric{}
@@ -157,6 +196,7 @@ func probeFirewallLoadBalance(c fortigatehttpclient.FortiHTTP, meta *TargetMetad
 				m = append(m, prometheus.MustNewConstMetric(realServerSessions, prometheus.GaugeValue, realServer.ActiveSessions, r.VDOM, virtualServer.Name, strconv.Itoa(realServer.ID)))
 				m = append(m, prometheus.MustNewConstMetric(realServerRTT, prometheus.GaugeValue, realServerRTTValue, r.VDOM, virtualServer.Name, strconv.Itoa(realServer.ID)))
 				m = append(m, prometheus.MustNewConstMetric(realServerBytesProcessed, prometheus.CounterValue, realServer.BytesProcessed, r.VDOM, virtualServer.Name, strconv.Itoa(realServer.ID)))
+				m = append(m, prometheus.MustNewConstMetric(realServerMaxConnections, prometheus.GaugeValue, float64(maxConnections[r.VDOM+"\x00"+virtualServer.Name][realServer.ID]), r.VDOM, virtualServer.Name, strconv.Itoa(realServer.ID)))
 			}
 		}
 	}

--- a/pkg/probe/firewall_load_balance_test.go
+++ b/pkg/probe/firewall_load_balance_test.go
@@ -24,6 +24,7 @@ import (
 func TestFirewallLoadBalance(t *testing.T) {
 	c := newFakeClient()
 	c.prepare("api/v2/monitor/firewall/load-balance?vdom=*&start=0&count=1000", "testdata/fw-loadbalancers.jsonnet")
+	c.prepare("api/v2/cmdb/firewall/vip?vdom=*", "testdata/fw-loadbalancers-vip-config.jsonnet")
 	r := prometheus.NewPedanticRegistry()
 	if !testProbe(probeFirewallLoadBalance, c, r) {
 		t.Errorf("testLoadBalanceServers() returned non-success")
@@ -42,6 +43,12 @@ func TestFirewallLoadBalance(t *testing.T) {
 	fortigate_lb_real_server_info{id="2",ip="10.10.0.2",port="8080",vdom="root",virtual_server="LB-EXAMPLE"} 1
 	fortigate_lb_real_server_info{id="3",ip="10.10.0.3",port="8080",vdom="root",virtual_server="LB-EXAMPLE"} 1
 	fortigate_lb_real_server_info{id="4",ip="10.10.0.4",port="8080",vdom="root",virtual_server="LB-EXAMPLE"} 1
+	# HELP fortigate_lb_real_server_max_connections Configured maximum concurrent connections for this real server (0 = unlimited)
+	# TYPE fortigate_lb_real_server_max_connections gauge
+	fortigate_lb_real_server_max_connections{id="1",vdom="root",virtual_server="LB-EXAMPLE"} 10000
+	fortigate_lb_real_server_max_connections{id="2",vdom="root",virtual_server="LB-EXAMPLE"} 5000
+	fortigate_lb_real_server_max_connections{id="3",vdom="root",virtual_server="LB-EXAMPLE"} 0
+	fortigate_lb_real_server_max_connections{id="4",vdom="root",virtual_server="LB-EXAMPLE"} 2000
 	# HELP fortigate_lb_real_server_mode Mode of this real server: active, standby or disabled
 	# TYPE fortigate_lb_real_server_mode gauge
 	fortigate_lb_real_server_mode{id="1",mode="active",vdom="root",virtual_server="LB-EXAMPLE"} 1

--- a/pkg/probe/testdata/fw-loadbalancers-vip-config.jsonnet
+++ b/pkg/probe/testdata/fw-loadbalancers-vip-config.jsonnet
@@ -1,0 +1,29 @@
+# api/v2/cmdb/firewall/vip?vdom=*
+[
+  {
+    "results":[
+      {
+        "name":"LB-EXAMPLE",
+        "realservers":[
+          {
+            "id":1,
+            "max-connections":10000
+          },
+          {
+            "id":2,
+            "max-connections":5000
+          },
+          {
+            "id":3,
+            "max-connections":0
+          },
+          {
+            "id":4,
+            "max-connections":2000
+          }
+        ]
+      }
+    ],
+    "vdom":"root"
+  }
+]


### PR DESCRIPTION
This pr introduces a `fortigate_lb_real_server_max_connections` metric to accompany the existing `fortigate_lb_real_server_active_sessions` metric. Together they can be used to alert on hitting the configured connections limit.

E.g. (promql)
```
(fortigate_lb_real_server_active_sessions >= fortigate_lb_real_server_max_connections)
and (fortigate_lb_real_server_max_connections != 0)
```

fixes #433