### PR TITLE
style(probe): reformat multi-line metric calls for gofumpt

### DIFF
--- a/pkg/probe/system_resources_usage.go
+++ b/pkg/probe/system_resources_usage.go
@@ -76,7 +76,8 @@ func probeSystemResourceUsage(c fortigatehttpclient.FortiHTTP, _ *TargetMetadata
 	m := []prometheus.Metric{}
 	for i, cpu := range sr.Results.CPU[1:] {
 		m = append(m, prometheus.MustNewConstMetric(
-			mResCPU, prometheus.GaugeValue, float64(cpu.Current)/100.0, fmt.Sprintf("%d", i)))
+			mResCPU, prometheus.GaugeValue, float64(cpu.Current)/100.0, fmt.Sprintf("%d", i),
+		))
 	}
 	m = append(m, prometheus.MustNewConstMetric(mResMemory, prometheus.GaugeValue, float64(sr.Results.Mem[0].Current)/100.0))
 	m = append(m, prometheus.MustNewConstMetric(mResSession, prometheus.GaugeValue, float64(sr.Results.Session[0].Current), "ipv4"))

--- a/pkg/probe/vpn_ipsec.go
+++ b/pkg/probe/vpn_ipsec.go
@@ -88,10 +88,12 @@ func probeVPNIPSec(c fortigatehttpclient.FortiHTTP, _ *TargetMetadata) ([]promet
 			}
 			m = append(m, prometheus.MustNewConstMetric(
 				parentTransmitted, prometheus.CounterValue,
-				i.OutgoingBytes, v.VDOM, i.Name))
+				i.OutgoingBytes, v.VDOM, i.Name,
+			))
 			m = append(m, prometheus.MustNewConstMetric(
 				parentReceived, prometheus.CounterValue,
-				i.IncomingBytes, v.VDOM, i.Name))
+				i.IncomingBytes, v.VDOM, i.Name,
+			))
 			for _, t := range i.ProxyID {
 				s := 0.0
 				if t.Status == "up" {


### PR DESCRIPTION
golangci-lint v2.13.1, introduced by the upstream common-file sync in PR #436, ships a gofumpt version that requires the closing paren of a multi-line function call to sit on its own line with a trailing comma. Reformat the affected prometheus.MustNewConstMetric calls in system_resources_usage.go and vpn_ipsec.go so lint passes under the new formatter.